### PR TITLE
exfat-utils: fix memleak in exfat_zero_out_disk

### DIFF
--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -488,6 +488,7 @@ static int exfat_zero_out_disk(struct exfat_blk_dev *bd,
 		total_written += nbytes;
 	} while (total_written <= size);
 
+	free(buf);
 	exfat_msg(EXFAT_DEBUG,
 		"zero out written size : %llu, disk size : %llu\n",
 		total_written, bd->size);

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -582,8 +582,13 @@ int main(int argc, char *argv[])
 	}
 
 	opterr = 0;
-	while ((c = getopt_long(argc, argv, "l:c:fVvh", opts, NULL)) != EOF)
+	while ((c = getopt_long(argc, argv, "n:l:c:fVvh", opts, NULL)) != EOF)
 		switch (c) {
+		/*
+		 * Make 'n' option fallback to 'l' option for for backward
+		 * compatibility with old utils.
+		 */
+		case 'n':
 		case 'l':
 		{
 			ret = exfat_iconv_enc(&exfat_iconv, optarg,


### PR DESCRIPTION
Dexter static analysis tools alarm memleak:
	Memory leak: buf in exfat_zero_out_disk

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>